### PR TITLE
Update plugin-publish-plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ scmRepoName = build-commons.git
 
 gradleVersionToUse = 3.1
 apivizVersion = 1.3.2.GA
-gradlePublishPluginVersion = 0.9.6
+gradlePublishPluginVersion = 0.9.9
 grgitVersion = 1.6.0-rc.1
 nexusStagingVersion = 0.5.3
 


### PR DESCRIPTION
Hi again!

I was doing a scan of the Gradle Plugin Portal and noticed you are using an old version of the `plugin-publish-plugin`.

There was a [bug in versions prior to 0.9.7](https://discuss.gradle.org/t/plugin-authors-please-use-the-latest-plugin-publish-plugin-others-may-result-in-a-broken-upload/23573), where artifacts would silently not be pushed into the repo, which means the latest version of your plugin will not work properly when people apply it to their build.

Upgrading to the latest version of the `plugin-publish-plugin` will fix this, but this will require pushing a new version of your plugin.

1. apply the PR
2. publish a new version of your plugin

Thanks (and sorry about that).

Let us know here [or in the forums](https://discuss.gradle.org/c/help-discuss/plugin-portal) if you need more assistance.